### PR TITLE
[LNK4197] Remove redundant exports. Issue #1

### DIFF
--- a/TlDatLexer/exports.def
+++ b/TlDatLexer/exports.def
@@ -1,11 +1,5 @@
 LIBRARY
 EXPORTS
-	isUnicode
-	getName
-	getFuncsArray
-	setInfo
-	beNotified
-	messageProc
 	GetLexerCount
 	GetLexerName
 	GetLexerStatusText


### PR DESCRIPTION
Removed redundant exports from `exports.def`. 

[<https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-warning-lnk4197?view=vs-2015>] 